### PR TITLE
UninitializedSaveTest

### DIFF
--- a/Content.Shared/_Starlight/Revolutionary/Components/RevSupplyRiftComponent.cs
+++ b/Content.Shared/_Starlight/Revolutionary/Components/RevSupplyRiftComponent.cs
@@ -33,5 +33,5 @@ public sealed partial class RevSupplyRiftComponent : Component
     /// The name of the player who placed the rift.
     /// </summary>
     [DataField]
-    public string? PlacedBy = null;
+    public string PlacedBy = "Unknown";
 }

--- a/Resources/Prototypes/_StarLight/Body/Organs/abductor.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/abductor.yml
@@ -75,8 +75,6 @@
     layers:
       - state: lung-l
       - state: lung-r
-  - type: Lung
-    alert: LowNitrogen
 
 - type: entity
   id: OrganAbductorHeart

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/cloaks.yml
@@ -25,6 +25,9 @@
           tags:
             - PowerCell
             - PowerCellSmall
+  - type: ContainerContainer
+    containers:
+      cell_slot: !type:ContainerSlot
   - type: EnergyDomeGenerator
     damageEnergyDraw: 8
     domePrototype: EnergyDomeSmallCap

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Materials/misc.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Materials/misc.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseXenoArtifact]
   id: AbyssCore
   name: abyssium core
   description: Bright crystal, oozing with energy.

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Reflector/reflector.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Reflector/reflector.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: Reflector
+  parent: BaseStructure
   name: reflector
   placement:
     mode: SnapgridCenter
@@ -11,7 +12,6 @@
   - type: Anchorable
   - type: Pullable
   - type: Rotatable
-  - type: Machine
   - type: Clickable
   - type: Physics
     bodyType: Static


### PR DESCRIPTION
- give rev rift the correct unknown value on init, so that it isn't being filled every component init
- remove abductor nitrogen sense, they don't breathe, are totally space-proof, and the lung comp addition was fucking with the two parent prototypes
- add proper cell container to captain's shield cloak thing
- make the abyssium core properly derive from baseartifact
- remove machine comp from reflector (it has no machine board, for all intents and purposes it is just a structure)